### PR TITLE
Fix calendar and weather features with HAL9000 animation

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -35,7 +35,11 @@ $(document).ready(function() {
         if (settings.ipadMode) $('body').addClass('ipad-layout');
         if (!settings.showRss) $('.news-container').hide();
         if (!settings.showWeather) $('#weather').hide();
-        if (!settings.showCalendar) $('#calendar-container').hide();
+        if (!settings.showCalendar) {
+            $('#calendar-container').hide();
+        } else {
+            $('.main-content').addClass('calendar-active');
+        }
     }
 
     // --- アラーム関連 ---
@@ -108,7 +112,9 @@ $(document).ready(function() {
             const date = new Date(year, month, day);
             let classes = 'calendar-day';
             if (day === today) classes += ' today';
-            if (settings.showHolidays && holiday_jp.isHoliday(date)) classes += ' holiday';
+            if (settings.showHolidays && typeof holiday_jp !== 'undefined' && holiday_jp.isHoliday(date)) {
+                classes += ' holiday';
+            }
             html += `<div class="${classes}">${day}</div>`;
         }
         html += '</div>';
@@ -119,18 +125,18 @@ $(document).ready(function() {
     function animateElement(selector) {
         const $element = $(selector);
         if ($element.is(':hidden')) return;
-        
+
         $element.removeClass('hidden-on-load').addClass('blinking');
         setTimeout(() => {
-            $element.removeClass('blinking').addClass('fade-in');
+            $element.removeClass('blinking');
+            setTimeout(() => $element.addClass('fade-in'), 500);
         }, 450); // 3 blinks * 150ms
     }
 
     function startUpSequence() {
-        animateElement('.clock-container');
-        animateElement('#calendar-container');
+        animateElement('.clock-container, .seconds-wrapper, #calendar-container');
         setTimeout(() => animateElement('.news-container'), 1000);
-        setTimeout(() => animateElement('.meta-container, .seconds-wrapper'), 2000);
+        setTimeout(() => animateElement('.meta-container'), 2000);
     }
 
     // --- データ取得・更新関数 ---
@@ -140,12 +146,12 @@ $(document).ready(function() {
     }
 
     function fetchWeather() {
-        if (!settings.showWeather || !settings.lat || !settings.lon) {
+        if (!settings.showWeather || !settings.latitude || !settings.longitude) {
             if (settings.showWeather) $('#weather').text('位置情報が設定されていません。');
             return;
         }
         console.log("天気情報を取得中...");
-        $.get(`/api/weather?lat=${settings.lat}&lon=${settings.lon}`, function(data) {
+        $.get(`/api/weather?lat=${settings.latitude}&lon=${settings.longitude}`, function(data) {
             let html = `<div>${data.name} (緯度:${data.coord.lat.toFixed(2)}, 経度:${data.coord.lon.toFixed(2)})</div>`;
             html += `<div><img src="https://openweathermap.org/img/wn/${data.weather[0].icon}@2x.png" alt="${data.weather[0].description}" style="vertical-align: middle; height: 2em; margin-right: 0.2em;"><span style="font-size: 1.5em; vertical-align: middle;">${data.main.temp.toFixed(1)}°C</span> (${data.weather[0].description})</div>`;
             html += `<div><span style="color: #ff6347;">${data.main.temp_max.toFixed(1)}°C</span> / <span style="color: #4682b4;">${data.main.temp_min.toFixed(1)}°C</span> (体感: ${data.main.feels_like.toFixed(1)}°C)</div>`;

--- a/public/style.css
+++ b/public/style.css
@@ -83,3 +83,20 @@ body:not(.settings-body) { overflow: hidden; }
 .ipad-layout .news-container, .ipad-layout #date { font-size: clamp(20px, 3vh, 28px); }
 .ipad-layout #weather { font-size: clamp(16px, 2vh, 18px); }
 .ipad-layout #calendar-container { display: none; }
+
+/* --- HAL9000 Animation --- */
+.hidden-on-load { opacity: 0; }
+.blinking { animation: blink-animation 0.45s linear; }
+@keyframes blink-animation {
+    0%, 33%, 67%, 100% { opacity: 1; }
+    17%, 50%, 83% { opacity: 0; }
+}
+.fade-in { animation: fade-in 1s ease forwards; }
+@keyframes fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+/* Layout adjustments when calendar is visible */
+.main-content.calendar-active { justify-content: flex-end; }
+.main-content.calendar-active .clock-container { margin-right: 30px; }


### PR DESCRIPTION
## Summary
- adjust UI initialization to add `calendar-active` class when calendar is shown
- prevent calendar rendering errors when the holiday library is missing
- use stored latitude and longitude to fetch weather data
- implement HAL9000 style blinking/fade animations
- update start-up sequence for staggered animation timing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687f4fed90808323824feacdf80416fd