### PR TITLE
Center calendar and add cinematic theme modes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,8 @@
                 <span class="clock-digit">0</span><span class="clock-digit">0</span>
             </div>
         </div>
+        <!-- カレンダー表示エリア -->
+        <div id="calendar-container" class="hidden-on-load"></div>
     </div>
 
     <footer class="footer-container">
@@ -42,8 +44,6 @@
                 <div id="second-decimals">.0000</div>
             </div>
         </div>
-        <!-- カレンダー表示エリア -->
-        <div id="calendar-container" class="hidden-on-load"></div>
         <!-- メタ情報（天気、日付）のコンテナ -->
         <div class="meta-container hidden-on-load">
              <div id="weather">

--- a/public/script.js
+++ b/public/script.js
@@ -8,7 +8,8 @@ $(document).ready(function() {
             highPrecisionSeconds: false, alarmTime: '', enableAlarm: false,
             enableChime: false, enableQuake: false, quakeThreshold: 1,
             showWind: true, showPressure: true, showVisibility: true,
-            ipadMode: false, nexus5xMode: false, debugOverlayEnabled: false
+            ipadMode: false, nexus5xMode: false, debugOverlayEnabled: false,
+            designTheme: 'default'
         };
         // 保存された設定とデフォルト値をマージ
         return { ...defaults, ...savedSettings };
@@ -46,6 +47,9 @@ $(document).ready(function() {
         if (settings.nexus5xMode) $('body').addClass('nexus5x-layout');
         if (!settings.showRss) $('.news-container').hide();
         if (!settings.showWeather) $('#weather').hide();
+        if (settings.designTheme && settings.designTheme !== 'default') {
+            $('body').addClass(`theme-${settings.designTheme}`);
+        }
         if (!settings.showCalendar || settings.nexus5xMode) {
             $('#calendar-container').hide();
             $('body').removeClass('calendar-active');

--- a/public/settings.html
+++ b/public/settings.html
@@ -37,9 +37,20 @@
                 <input class="form-check-input" type="checkbox" role="switch" id="show-calendar">
                 <label class="form-check-label" for="show-calendar">カレンダー</label>
             </div>
-             <div class="ps-4 form-check form-switch" id="show-holidays-wrapper">
-                <input class="form-check-input" type="checkbox" role="switch" id="show-holidays">
-                <label class="form-check-label" for="show-holidays">祝日表示 (カレンダーON時)</label>
+            <div class="ps-4 form-check form-switch" id="show-holidays-wrapper">
+               <input class="form-check-input" type="checkbox" role="switch" id="show-holidays">
+               <label class="form-check-label" for="show-holidays">祝日表示 (カレンダーON時)</label>
+           </div>
+
+            <h5 class="mt-4">デザインテーマ</h5>
+            <div class="form-group mb-3">
+                <label for="design-theme" class="form-label">テーマ:</label>
+                <select id="design-theme" class="form-select">
+                    <option value="default">標準</option>
+                    <option value="blade-runner">ブレード・ランナー風</option>
+                    <option value="evangelion">エヴァンゲリオン風</option>
+                    <option value="space2001">2001年宇宙の旅風</option>
+                </select>
             </div>
 
             <hr>
@@ -232,7 +243,8 @@
                     highPrecisionSeconds: false, alarmTime: '', enableAlarm: false,
                     enableChime: false, enableQuake: false, quakeThreshold: 1,
                     showWind: true, showPressure: true, showVisibility: true,
-                    ipadMode: false, nexus5xMode: false, debugOverlayEnabled: false
+                    ipadMode: false, nexus5xMode: false, debugOverlayEnabled: false,
+                    designTheme: 'default'
                 };
                 const settings = { ...defaults, ...savedSettings };
 
@@ -260,6 +272,7 @@
                 $('#ipad-mode').prop('checked', settings.ipadMode);
                 $('#nexus5x-mode').prop('checked', settings.nexus5xMode);
                 $('#debug-overlay').prop('checked', settings.debugOverlayEnabled);
+                $('#design-theme').val(settings.designTheme);
                 
                 toggleHolidayOption();
                 toggleQuakeOption();
@@ -295,7 +308,8 @@
                     showVisibility: $('#show-visibility').prop('checked'),
                     ipadMode: $('#ipad-mode').prop('checked'),
                     nexus5xMode: $('#nexus5x-mode').prop('checked'),
-                    debugOverlayEnabled: $('#debug-overlay').prop('checked')
+                    debugOverlayEnabled: $('#debug-overlay').prop('checked'),
+                    designTheme: $('#design-theme').val()
                 };
 
                 Cookies.set('dashboardSettings', JSON.stringify(settingsToSave), { expires: 365 });

--- a/public/style.css
+++ b/public/style.css
@@ -13,7 +13,7 @@ body, html {
 body:not(.settings-body) { overflow: hidden; }
 
 /* メインコンテンツエリア (時計) */
-.main-content { flex-grow: 1; display: flex; align-items: center; justify-content: center; padding: 30px 0; position: relative; }
+.main-content { flex-grow: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 20px; padding: 30px 0; position: relative; }
 .clock-container { text-align: center; }
 #clock { font-family: 'Orbitron', sans-serif; font-size: clamp(100px, 22vw, 300px); font-weight: 700; text-shadow: 0 0 10px rgba(255, 255, 255, 0.3); display: flex; align-items: center; justify-content: center; gap: 0.1em; }
 .clock-digit { width: 0.7em; text-align: center; }
@@ -60,11 +60,9 @@ body.calendar-active .footer-container {
 
 /* --- カレンダー --- */
 #calendar-container {
-    position: absolute;
-    left: 30px;
-    bottom: clamp(100px, 20vh, 180px);
     font-size: clamp(10px, 1.2vw, 16px);
     width: clamp(180px, 25vw, 300px);
+    margin: 0 auto;
 }
 .calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 5px; }
 .calendar-header { text-align: center; font-weight: bold; margin-bottom: 10px; font-size: 1.5em; }
@@ -169,3 +167,34 @@ body.calendar-active .footer-container {
     from { opacity: 0; }
     to { opacity: 1; }
 }
+
+/* --- デザインテーマ --- */
+body.theme-blade-runner {
+    background-color: #001;
+    color: #0ff;
+}
+body.theme-blade-runner .news-container { border-color: #0ff; }
+body.theme-blade-runner #clock,
+body.theme-blade-runner .second-digit,
+body.theme-blade-runner #second-decimals,
+body.theme-blade-runner .clock-separator { color: #0ff; }
+
+body.theme-evangelion {
+    background-color: #25002e;
+    color: #39ff14;
+}
+body.theme-evangelion .news-container { border-color: #39ff14; }
+body.theme-evangelion #clock,
+body.theme-evangelion .second-digit,
+body.theme-evangelion #second-decimals,
+body.theme-evangelion .clock-separator { color: #39ff14; }
+
+body.theme-space2001 {
+    background-color: #000;
+    color: #f00;
+}
+body.theme-space2001 .news-container { border-color: #f00; }
+body.theme-space2001 #clock,
+body.theme-space2001 .second-digit,
+body.theme-space2001 #second-decimals,
+body.theme-space2001 .clock-separator { color: #f00; }


### PR DESCRIPTION
## Summary
- Move calendar under the clock and above RSS ticker to avoid overlap with weather
- Introduce Blade Runner, Evangelion, and 2001: A Space Odyssey design themes selectable from settings

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689adca435488323a4f6ee9fb6046084