### PR TITLE
Resize calendar and refine cinematic themes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
     <!-- デジタル時計風フォント(Orbitron)をGoogle Fontsから読み込みます -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&family=Share+Tech+Mono&family=Seven+Segment&display=swap" rel="stylesheet">
     <!-- スタイルシートを読み込みます -->
     <link rel="stylesheet" href="style.css">
 </head>
@@ -30,6 +30,8 @@
                 <span class="clock-digit">0</span><span class="clock-digit">0</span>
             </div>
         </div>
+        <!-- カレンダー表示エリア -->
+        <div id="calendar-container" class="hidden-on-load"></div>
     </div>
 
     <footer class="footer-container">
@@ -42,8 +44,6 @@
                 <div id="second-decimals">.0000</div>
             </div>
         </div>
-        <!-- カレンダー表示エリア -->
-        <div id="calendar-container" class="hidden-on-load"></div>
         <!-- メタ情報（天気、日付）のコンテナ -->
         <div class="meta-container hidden-on-load">
              <div id="weather">

--- a/public/script.js
+++ b/public/script.js
@@ -8,7 +8,8 @@ $(document).ready(function() {
             highPrecisionSeconds: false, alarmTime: '', enableAlarm: false,
             enableChime: false, enableQuake: false, quakeThreshold: 1,
             showWind: true, showPressure: true, showVisibility: true,
-            ipadMode: false, nexus5xMode: false, debugOverlayEnabled: false
+            ipadMode: false, nexus5xMode: false, debugOverlayEnabled: false,
+            designTheme: 'default'
         };
         // 保存された設定とデフォルト値をマージ
         return { ...defaults, ...savedSettings };
@@ -46,6 +47,9 @@ $(document).ready(function() {
         if (settings.nexus5xMode) $('body').addClass('nexus5x-layout');
         if (!settings.showRss) $('.news-container').hide();
         if (!settings.showWeather) $('#weather').hide();
+        if (settings.designTheme && settings.designTheme !== 'default') {
+            $('body').addClass(`theme-${settings.designTheme}`);
+        }
         if (!settings.showCalendar || settings.nexus5xMode) {
             $('#calendar-container').hide();
             $('body').removeClass('calendar-active');

--- a/public/settings.html
+++ b/public/settings.html
@@ -10,6 +10,9 @@
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     <!-- Custom CSS -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&family=Share+Tech+Mono&family=Seven+Segment&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body class="bg-dark text-light settings-body">
@@ -37,9 +40,20 @@
                 <input class="form-check-input" type="checkbox" role="switch" id="show-calendar">
                 <label class="form-check-label" for="show-calendar">カレンダー</label>
             </div>
-             <div class="ps-4 form-check form-switch" id="show-holidays-wrapper">
-                <input class="form-check-input" type="checkbox" role="switch" id="show-holidays">
-                <label class="form-check-label" for="show-holidays">祝日表示 (カレンダーON時)</label>
+            <div class="ps-4 form-check form-switch" id="show-holidays-wrapper">
+               <input class="form-check-input" type="checkbox" role="switch" id="show-holidays">
+               <label class="form-check-label" for="show-holidays">祝日表示 (カレンダーON時)</label>
+           </div>
+
+            <h5 class="mt-4">デザインテーマ</h5>
+            <div class="form-group mb-3">
+                <label for="design-theme" class="form-label">テーマ:</label>
+                <select id="design-theme" class="form-select">
+                    <option value="default">標準</option>
+                    <option value="blade-runner">ブレード・ランナー風</option>
+                    <option value="evangelion">エヴァンゲリオン風</option>
+                    <option value="space2001">2001年宇宙の旅風</option>
+                </select>
             </div>
 
             <hr>
@@ -232,7 +246,8 @@
                     highPrecisionSeconds: false, alarmTime: '', enableAlarm: false,
                     enableChime: false, enableQuake: false, quakeThreshold: 1,
                     showWind: true, showPressure: true, showVisibility: true,
-                    ipadMode: false, nexus5xMode: false, debugOverlayEnabled: false
+                    ipadMode: false, nexus5xMode: false, debugOverlayEnabled: false,
+                    designTheme: 'default'
                 };
                 const settings = { ...defaults, ...savedSettings };
 
@@ -260,6 +275,7 @@
                 $('#ipad-mode').prop('checked', settings.ipadMode);
                 $('#nexus5x-mode').prop('checked', settings.nexus5xMode);
                 $('#debug-overlay').prop('checked', settings.debugOverlayEnabled);
+                $('#design-theme').val(settings.designTheme);
                 
                 toggleHolidayOption();
                 toggleQuakeOption();
@@ -295,7 +311,8 @@
                     showVisibility: $('#show-visibility').prop('checked'),
                     ipadMode: $('#ipad-mode').prop('checked'),
                     nexus5xMode: $('#nexus5x-mode').prop('checked'),
-                    debugOverlayEnabled: $('#debug-overlay').prop('checked')
+                    debugOverlayEnabled: $('#debug-overlay').prop('checked'),
+                    designTheme: $('#design-theme').val()
                 };
 
                 Cookies.set('dashboardSettings', JSON.stringify(settingsToSave), { expires: 365 });

--- a/public/style.css
+++ b/public/style.css
@@ -13,7 +13,7 @@ body, html {
 body:not(.settings-body) { overflow: hidden; }
 
 /* メインコンテンツエリア (時計) */
-.main-content { flex-grow: 1; display: flex; align-items: center; justify-content: center; padding: 30px 0; position: relative; }
+.main-content { flex-grow: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 20px; padding: 30px 0; position: relative; }
 .clock-container { text-align: center; }
 #clock { font-family: 'Orbitron', sans-serif; font-size: clamp(100px, 22vw, 300px); font-weight: 700; text-shadow: 0 0 10px rgba(255, 255, 255, 0.3); display: flex; align-items: center; justify-content: center; gap: 0.1em; }
 .clock-digit { width: 0.7em; text-align: center; }
@@ -60,19 +60,35 @@ body.calendar-active .footer-container {
 
 /* --- カレンダー --- */
 #calendar-container {
-    position: absolute;
-    left: 30px;
-    bottom: clamp(100px, 20vh, 180px);
-    font-size: clamp(10px, 1.2vw, 16px);
-    width: clamp(180px, 25vw, 300px);
+    font-size: clamp(8px, 1vw, 14px);
+    width: clamp(240px, 60vw, 600px);
+    margin: 0 auto;
 }
-.calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 5px; }
-.calendar-header { text-align: center; font-weight: bold; margin-bottom: 10px; font-size: 1.5em; }
-.calendar-day, .calendar-weekday { text-align: center; padding: 0.5em 0; }
+.calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    grid-auto-rows: 1.6em;
+    gap: 3px;
+}
+.calendar-header {
+    text-align: center;
+    font-weight: bold;
+    margin-bottom: 6px;
+    font-size: 1.2em;
+}
+.calendar-day,
+.calendar-weekday {
+    text-align: center;
+    padding: 0.2em 0;
+}
 .calendar-weekday { color: #888; }
-.calendar-day.today { background-color: #444; border-radius: 50%; }
+.calendar-day.today { background-color: #444; border-radius: 4px; }
 .calendar-day.holiday { color: #ff6347; }
 .calendar-day.other-month { color: #555; }
+
+body.calendar-active .main-content {
+    justify-content: flex-start;
+}
 
 /* --- アラーム --- */
 .alarm-ringing { animation: alarm-flash 1s infinite; }
@@ -168,4 +184,93 @@ body.calendar-active .footer-container {
 @keyframes fade-in {
     from { opacity: 0; }
     to { opacity: 1; }
+}
+
+/* --- デザインテーマ --- */
+body.theme-blade-runner {
+    background-color: #020914;
+    color: rgba(0, 255, 255, 0.8);
+    font-family: 'Share Tech Mono', monospace;
+    background-image:
+        radial-gradient(circle at center, rgba(0,255,255,0.1) 0%, transparent 70%),
+        linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6));
+}
+body.theme-blade-runner .news-container { border-color: rgba(0,255,255,0.8); }
+body.theme-blade-runner #clock,
+body.theme-blade-runner .second-digit,
+body.theme-blade-runner #second-decimals,
+body.theme-blade-runner .clock-separator {
+    color: rgba(0,255,255,0.8);
+    text-shadow: 0 0 8px rgba(0,255,255,0.7);
+}
+
+body.theme-evangelion {
+    background-color: #2d0000;
+    color: #ff0000;
+    font-family: 'Seven Segment', monospace;
+    background-image: repeating-linear-gradient(135deg, rgba(255,0,0,0.2) 0 10px, transparent 10px 20px);
+}
+body.theme-evangelion .news-container { border-color: #ff0000; }
+body.theme-evangelion #clock,
+body.theme-evangelion .second-digit,
+body.theme-evangelion #second-decimals,
+body.theme-evangelion .clock-separator {
+    color: #ff0000;
+    text-shadow: 0 0 6px rgba(255,0,0,0.6);
+}
+body.theme-evangelion #weather::before {
+    content: '\5929\6c17';
+    display: block;
+    font-size: 0.7em;
+    letter-spacing: 0.1em;
+}
+body.theme-evangelion #seconds::before {
+    content: '\79d2';
+    display: block;
+    font-size: 0.7em;
+    text-align: center;
+    letter-spacing: 0.1em;
+}
+body.theme-evangelion #calendar-container::before {
+    content: '\66dc';
+    display: block;
+    font-size: 0.7em;
+    text-align: center;
+    margin-bottom: 2px;
+    letter-spacing: 0.1em;
+}
+
+body.theme-space2001 {
+    background-color: #000;
+    color: #0ff;
+    font-family: 'Courier New', monospace;
+    position: relative;
+    overflow: hidden;
+}
+body.theme-space2001 .news-container { border-color: #0ff; }
+body.theme-space2001 #clock,
+body.theme-space2001 .second-digit,
+body.theme-space2001 #second-decimals,
+body.theme-space2001 .clock-separator {
+    color: #0ff;
+    text-shadow: 0 0 8px rgba(0,255,255,0.7);
+}
+body.theme-space2001::before {
+    content: 'ANTENNA\A \03A3=\2211\A GALAXY\A \03A9 = mc^2\A COSMOS\A VECTOR';
+    position: absolute;
+    top: 100%;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    font-size: clamp(12px, 2vw, 20px);
+    line-height: 1.2;
+    white-space: pre;
+    color: rgba(255,255,255,0.1);
+    pointer-events: none;
+    animation: space2001-scroll 20s linear infinite;
+}
+
+@keyframes space2001-scroll {
+    from { transform: translateY(0); }
+    to { transform: translateY(-200%); }
 }


### PR DESCRIPTION
## Summary
- Resize calendar to a wide rectangular layout so weather, seconds, date, and RSS remain visible
- Style Blade Runner, Evangelion, and 2001: A Space Odyssey modes with bespoke fonts, overlays, and animated backgrounds
- Load new Google fonts for theme typography

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689adca435488323a4f6ee9fb6046084